### PR TITLE
Fix gradle build time out problem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.2.0-alpha14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
         classpath 'com.google.gms:google-services:3.2.0'
-        classpath 'io.fabric.tools:gradle:1.25.1'
+        classpath 'io.fabric.tools:gradle:+'
     }
 }
 


### PR DESCRIPTION
Could not get resource 'https://maven.fabric.io/public/io/fabric/tools/gradle/1.25.1/gradle-1.25.1.jar'