### PR TITLE
feat: add selectable text for row items on android and desktop, defaults on ios

### DIFF
--- a/shared/src/androidMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
+++ b/shared/src/androidMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
@@ -1,0 +1,24 @@
+package com.kgurgul.cpuinfo.ui.components
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+actual fun SelectableText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier
+) {
+    SelectionContainer {
+        Text(
+            text = text,
+            style = style,
+            color = color,
+            modifier = modifier
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/kgurgul/cpuinfo/ui/components/ItemValueRow.kt
+++ b/shared/src/commonMain/kotlin/com/kgurgul/cpuinfo/ui/components/ItemValueRow.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.kgurgul.cpuinfo.ui.theme.spacingXSmall
+import com.kgurgul.cpuinfo.ui.components.SelectableText
 
 @Composable
 fun ItemValueRow(
@@ -24,7 +25,7 @@ fun ItemValueRow(
             .then(modifier),
     ) {
         val titleWeight = if (value == null) 1f else .4f
-        Text(
+        SelectableText(
             text = title,
             style = MaterialTheme.typography.titleSmall,
             color = contentColor,
@@ -32,7 +33,7 @@ fun ItemValueRow(
         )
         value?.let {
             Spacer(modifier = Modifier.size(spacingXSmall))
-            Text(
+            SelectableText(
                 text = it,
                 style = MaterialTheme.typography.bodyMedium,
                 color = contentColor.copy(alpha = .7f),
@@ -41,3 +42,4 @@ fun ItemValueRow(
         }
     }
 }
+

--- a/shared/src/commonMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
+++ b/shared/src/commonMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
@@ -1,0 +1,14 @@
+package com.kgurgul.cpuinfo.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+expect fun SelectableText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier
+)

--- a/shared/src/desktopMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
+++ b/shared/src/desktopMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
@@ -1,0 +1,24 @@
+package com.kgurgul.cpuinfo.ui.components
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+actual fun SelectableText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier
+) {
+    SelectionContainer {
+        Text(
+            text = text,
+            style = style,
+            color = color,
+            modifier = modifier
+        )
+    }
+}

--- a/shared/src/iosMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
+++ b/shared/src/iosMain/kotlin/com/kgurgul/cpuinfo/ui/components/SelectableText.kt
@@ -1,0 +1,22 @@
+package com.kgurgul.cpuinfo.ui.components
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+
+@Composable
+actual fun SelectableText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    modifier: Modifier
+) {
+    Text(
+        text = text,
+        style = style,
+        color = color,
+        modifier = modifier
+    )
+}


### PR DESCRIPTION
I don't have a mac to test; I also read its not supported.  This provides selection and copy.
Thanks for the cool KMP app.