### PR TITLE
[SHARED] Fix kelvin symbol (SI Unit)

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -221,7 +221,7 @@
     <string name="no_temp_data">Sorry I can't find temperature sensors :-(</string>
     <string name="celsius" translatable="false">&#176;C</string>
     <string name="fahrenheit" translatable="false">&#176;F</string>
-    <string name="kelvin" translatable="false">&#176;K</string>
+    <string name="kelvin" translatable="false">K</string>
     <string name="temp_thermal_state">Thermal state: %1$s</string>
     <string name="temp_thermal_state_nominal">Nominal</string>
     <string name="temp_thermal_state_fair">Fair</string>

--- a/shared/src/commonMain/kotlin/com/kgurgul/cpuinfo/features/temperature/TemperatureFormatter.kt
+++ b/shared/src/commonMain/kotlin/com/kgurgul/cpuinfo/features/temperature/TemperatureFormatter.kt
@@ -37,7 +37,7 @@ class TemperatureFormatter(
         } else {
             return if (tempUnit == KELVIN) {
                 val kelvin = temp + 273.15
-                "${kelvin.round2()}\u00B0K"
+                "${kelvin.round2()} K"
             } else {
                 val tempFormatted = "${temp.toInt()}\u00B0C"
                 tempFormatted


### PR DESCRIPTION
## 🚀 Description

Fix: Remove the incorrect "°" prefix before the kelvin symbol.
The kelvin unit (K) should not be preceded by a degree symbol (°), as per the [International System of Units (SI) standard](https://www.bipm.org/en/si-base-units/kelvin).
 
## 📄 Motivation and Context

The current display includes a "°" before the kelvin symbol, which is incorrect according to the SI standard.
This fix ensures compliance with international standards, which is especially important for educational use.

## 🧪 How Has This Been Tested?

- Tested on the desktop application.

- Not tested on Android or iOS (I do not dev on mobile ...) 


## 📷 Screenshots (if appropriate)

<img width="788" height="580" alt="image" src="https://github.com/user-attachments/assets/f6d35cd4-9d07-4d3d-a424-dd6dd8d71ac4" />

<img width="788" height="580" alt="image" src="https://github.com/user-attachments/assets/e0578994-453e-4f54-81c5-32833538a106" />

<img width="788" height="580" alt="image" src="https://github.com/user-attachments/assets/70f0356c-ab4f-4236-a588-f81a8aedf9e1" />


## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This PR is a minor but important fix for accuracy, especially for educational use. I’m happy to adjust the code style or implementation if needed. Very great application btw, thank you for providing it !  